### PR TITLE
Fixed Middleware to use the cookie class set in Laravel 

### DIFF
--- a/src/Illuminate/Session/Middleware.php
+++ b/src/Illuminate/Session/Middleware.php
@@ -184,11 +184,23 @@ class Middleware implements HttpKernelInterface {
 
 		if ($this->sessionIsPersistent($c = $this->manager->getSessionConfig()))
 		{
-			$secure = array_get($c, 'secure', false);
+			$secure   = array_get($c, 'secure',   false);
+			$httpOnly = array_get($c, 'httpOnly', true);
 
-			$response->headers->setCookie(new Cookie(
-				$s->getName(), $s->getId(), $this->getCookieLifetime(), $c['path'], $c['domain'], $secure
-			));
+			if ( isset($this->app['cookie']) )
+			{
+				$cookie = $this->app['cookie']->make(
+					$s->getName(), $s->getId(), $c['lifetime'], $c['path'], $c['domain'], $secure, $httpOnly
+				);
+			}
+			else 
+			{
+				$cookie = new Cookie(
+					$s->getName(), $s->getId(), $this->getCookieLifetime(), $c['path'], $c['domain'], $secure, $httpOnly
+				);
+			}
+
+			$response->headers->setCookie($cookie);
 		}
 	}
 


### PR DESCRIPTION
**The problem I faced:**
The website I'm working on uses a bookmarklet that requires authentication. Since the bookmarklet loads via JS, laravel's session cookie is not accessible because the _httpOnly_ flag is set. 

So I have to disable the _httpOnly_ flag

**What I tried to solve the problem:**
I first tried setting a _httpOnly_ option in the config, didn't work because in all the cookie creation code, the httpOnly option is never passed in, it assumes the default of the method parameter. 

So I created my own Cookie class extending laravel's one and changing the default parameter value for httpOnly. It works when I create a cookie manually, but not when laravel creates the cookie. I could not figure out why it would behave that way. So I dug deeper. 

**What I found:**
I found that the cookie is being set in _Session/Middleware.php_ and to my surprise it only uses _Symfony\Component\HttpFoundation\Cookie_. There is no code which checks for which Cookie class is set by laravel, meaning there's no way for you to change the Cookie behavior unless you change the Middleware. Which doesn't make sense if you decided to change the way cookies are handle in laravel. Shouldn't need to change two classes for behavior change in one.  

**What I did:**
I added code to check for laravel's cookie class, if none is found it falls back to using symfony's cookie class directly. I also added to code to check the config for the _httpOnly_ flag, allowing devs to choose whether they want it set or not. 
